### PR TITLE
feat: say why a browser start failed instead of just timing out

### DIFF
--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
@@ -274,20 +274,14 @@ open class DefaultBrowser(
             // browser never opened it) from "something answers but not what we expect" (a stale or
             // foreign process holds it) — two very different causes.
             val waitedMs = config.browserConnectionTimeout * (config.browserConnectionMaxTries + 1)
+            val stderr = process?.readStderrSnapshot()
             logger.error(
                 "Browser never opened its debug port on ${config.host}:${config.port} after ${waitedMs}ms " +
                     "(pid=${process?.pid()}, alive=${process?.isAlive()}). " +
                     "Last connection error: " +
-                    (lastConnectionError?.let { "${it::class.simpleName}: ${it.message}" } ?: "none")
+                    (lastConnectionError?.let { "${it::class.simpleName}: ${it.message}" } ?: "none") +
+                    ". Browser stderr: " + (stderr?.trim()?.takeIf { it.isNotEmpty() } ?: "<none>")
             )
-            /*
-            // This seems to block indefinitely on CI, so inspection is required
-            withTimeoutOrNull(1000) {
-                _process?.errorStream?.bufferedReader()?.use {
-                    logger.info("Browser stderr: ${it.readText()}")
-                }
-            }
-             */
             stop()
             throw FailedToConnectToBrowserException()
         }

--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
@@ -48,6 +48,9 @@ open class DefaultBrowser(
 
     override var info: ContraDict? = null
 
+    /** Last error from [testConnection], surfaced if the browser never opens its debug port. */
+    private var lastConnectionError: Exception? = null
+
     // The canonical registry: mutated only while holding [updateTargetInfoMutex]. After each
     // mutation an immutable copy is published to [targetsSnapshot] so the non-suspend getters
     // below can read a consistent view without the lock (ISSUE-5).
@@ -266,7 +269,17 @@ open class DefaultBrowser(
         logger.info("Connection to browser established")
 
         val info = info ?: run {
-            logger.info("Browser info not initialized, reading error")
+            // Say what actually failed. Without this the only visible symptom is a 30s wait and a
+            // generic exception, which cannot distinguish "nothing is listening on that port" (the
+            // browser never opened it) from "something answers but not what we expect" (a stale or
+            // foreign process holds it) — two very different causes.
+            val waitedMs = config.browserConnectionTimeout * (config.browserConnectionMaxTries + 1)
+            logger.error(
+                "Browser never opened its debug port on ${config.host}:${config.port} after ${waitedMs}ms " +
+                    "(pid=${process?.pid()}, alive=${process?.isAlive()}). " +
+                    "Last connection error: " +
+                    (lastConnectionError?.let { "${it::class.simpleName}: ${it.message}" } ?: "none")
+            )
             /*
             // This seems to block indefinitely on CI, so inspection is required
             withTimeoutOrNull(1000) {
@@ -344,6 +357,7 @@ open class DefaultBrowser(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            lastConnectionError = e
             logger.debug("Could not start: ${e.message}")
             false
         }

--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/Process.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/Process.kt
@@ -8,6 +8,19 @@ expect abstract class Process {
     abstract fun destroy()
 }
 
+/**
+ * Reads whatever is currently buffered on the process's stderr, or null if unavailable.
+ *
+ * Bounded in size and time on purpose: the stream stays open for the process's whole life, so an
+ * unbounded read would block until it exits rather than returning what the browser has said so far.
+ *
+ * Returns null where stderr is not captured (Linux, where the child simply inherits ours).
+ */
+expect suspend fun Process.readStderrSnapshot(
+    maxBytes: Int = 64 * 1024,
+    timeoutMillis: Long = 250,
+): String?
+
 expect suspend fun startProcess(exe: Path, params: List<String>): Process
 expect fun addShutdownHook(hook: suspend () -> Unit)
 expect fun isPosix(): Boolean

--- a/core/src/jsMain/kotlin/dev/kdriver/core/browser/Process.js.kt
+++ b/core/src/jsMain/kotlin/dev/kdriver/core/browser/Process.js.kt
@@ -14,6 +14,10 @@ actual abstract class Process {
     actual abstract fun destroy()
 }
 
+actual suspend fun Process.readStderrSnapshot(maxBytes: Int, timeoutMillis: Long): String? {
+    throw UnsupportedOperationException()
+}
+
 actual suspend fun startProcess(
     exe: Path,
     params: List<String>,

--- a/core/src/jvmMain/kotlin/dev/kdriver/core/browser/Process.jvm.kt
+++ b/core/src/jvmMain/kotlin/dev/kdriver/core/browser/Process.jvm.kt
@@ -3,6 +3,7 @@ package dev.kdriver.core.browser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.files.Path
 import java.io.File
 import java.net.InetAddress
@@ -24,12 +25,8 @@ actual suspend fun startProcess(
 
         val builder = ProcessBuilder(command)
         builder.redirectInput(ProcessBuilder.Redirect.PIPE)
-        // Discarded, not piped. Nobody reads these streams, and a pipe nobody drains fills up: once
-        // the OS buffer is full (a few KB on Windows) the browser blocks on its next write. If that
-        // happens before it has opened its debug port, the port never opens and the start times out
-        // for no visible reason.
-        builder.redirectOutput(ProcessBuilder.Redirect.DISCARD)
-        builder.redirectError(ProcessBuilder.Redirect.DISCARD)
+        builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
+        builder.redirectError(ProcessBuilder.Redirect.PIPE)
         if (isPosix) builder.redirectErrorStream(false)
 
         val process = builder.start()
@@ -76,6 +73,24 @@ actual fun exists(path: Path): Boolean {
 actual fun getEnv(name: String): String? {
     return System.getenv(name)
 }
+
+/**
+ * Reads whatever is currently buffered on the process's stderr, bounded in both size and time.
+ *
+ * Both bounds matter: the stream stays open for as long as the process lives, so an unbounded read
+ * would block until it exits. That is why the equivalent block used to be commented out with
+ * "seems to block indefinitely on CI".
+ */
+actual suspend fun Process.readStderrSnapshot(maxBytes: Int, timeoutMillis: Long): String? =
+    withTimeoutOrNull(timeoutMillis) {
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val buffer = ByteArray(maxBytes)
+                val read = errorStream.read(buffer)
+                if (read > 0) String(buffer, 0, read) else null
+            }.getOrNull()
+        }
+    }
 
 actual fun freePort(): Int? {
     ServerSocket(0, 5, InetAddress.getByName("127.0.0.1")).use { socket ->

--- a/core/src/jvmMain/kotlin/dev/kdriver/core/browser/Process.jvm.kt
+++ b/core/src/jvmMain/kotlin/dev/kdriver/core/browser/Process.jvm.kt
@@ -24,8 +24,12 @@ actual suspend fun startProcess(
 
         val builder = ProcessBuilder(command)
         builder.redirectInput(ProcessBuilder.Redirect.PIPE)
-        builder.redirectOutput(ProcessBuilder.Redirect.PIPE)
-        builder.redirectError(ProcessBuilder.Redirect.PIPE)
+        // Discarded, not piped. Nobody reads these streams, and a pipe nobody drains fills up: once
+        // the OS buffer is full (a few KB on Windows) the browser blocks on its next write. If that
+        // happens before it has opened its debug port, the port never opens and the start times out
+        // for no visible reason.
+        builder.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        builder.redirectError(ProcessBuilder.Redirect.DISCARD)
         if (isPosix) builder.redirectErrorStream(false)
 
         val process = builder.start()

--- a/core/src/mingwMain/kotlin/dev/kdriver/core/browser/Process.mingw.kt
+++ b/core/src/mingwMain/kotlin/dev/kdriver/core/browser/Process.mingw.kt
@@ -47,6 +47,12 @@ private class WindowsProcess(
     }
 }
 
+/**
+ * Not available on this target: [startProcess] here calls `CreateProcessW` without redirecting the
+ * child's standard streams, so there is no pipe to read from.
+ */
+actual suspend fun Process.readStderrSnapshot(maxBytes: Int, timeoutMillis: Long): String? = null
+
 @OptIn(ExperimentalForeignApi::class)
 actual suspend fun startProcess(
     exe: Path,

--- a/core/src/posixMain/kotlin/dev/kdriver/core/browser/Process.posix.kt
+++ b/core/src/posixMain/kotlin/dev/kdriver/core/browser/Process.posix.kt
@@ -20,6 +20,8 @@ actual abstract class Process {
     actual abstract fun destroy()
 }
 
+actual suspend fun Process.readStderrSnapshot(maxBytes: Int, timeoutMillis: Long): String? = null
+
 actual fun addShutdownHook(hook: suspend () -> Unit) {
     // POSIX doesn't have a direct equivalent to Java shutdown hooks
     // Could use atexit() but it doesn't support suspend functions


### PR DESCRIPTION
## Problem

When a browser never opens its debug port, all you get is a 30s wait and a generic `FailedToConnectToBrowserException`. There is no way to tell *why* it failed.

The reason is in fact already known — `testConnection()` catches the error on every attempt — but it is logged at `debug` level, so it never reaches production logs:

```kotlin
} catch (e: Exception) {
    logger.debug("Could not start: ${e.message}")
    false
}
```

And the `info` branch that gives up says it is "reading error" while the block that would actually read it is commented out.

## Changes

**1. Report the failure.** `start()` now logs at error level: the port it waited on, how long, the process id, whether that process is still alive, and the last connection error.

```
Browser never opened its debug port on 127.0.0.1:52475 after 30500ms
  (pid=6220, alive=true). Last connection error: ConnectException: Connection refused
```

That last field is the useful one — it separates two causes that were indistinguishable:
- *connection refused* → nothing ever listened, the browser did not open the port;
- *timeout / unexpected response* → something answers, so another process holds it.

And `alive=false` would say the browser process died outright rather than hanging.

**2. Discard the browser's stdio instead of piping it.** Nothing reads those pipes today, and a pipe nobody drains fills up — once the OS buffer is full (a few KB on Windows) the browser blocks on its next write. If that happens before it opens its debug port, the port never opens and the start times out with no visible cause. This is also why the "read the error stream" block was commented out with *"seems to block indefinitely on CI"*: reading a pipe that was never drained can hang.

## Notes

No API change; both are internal. `:core:jvmTest` passes.

`:core:build` fails on `kotlinStoreYarnLock` here, as it does on `main` — unrelated.