### PR TITLE
fix: stop polling the debug port once the browser has answered

### DIFF
--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/AwaitConnection.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/AwaitConnection.kt
@@ -1,0 +1,28 @@
+package dev.kdriver.core.browser
+
+import kotlinx.coroutines.delay
+
+/**
+ * Polls [isConnected] until it succeeds, at most [maxTries] times, waiting [intervalMillis] after
+ * each failed attempt.
+ *
+ * Extracted from `DefaultBrowser.start` so the polling rule can be tested without a real browser.
+ * It used to be written as `repeat(maxTries) { if (testConnection()) return@repeat; delay(…) }`,
+ * which does not do what it reads like: `return@repeat` returns from the *lambda*, so it is a
+ * `continue`, not a `break`. The loop therefore never stopped early — and since the skipped line was
+ * the `delay`, a browser that answered on the first try still got all the remaining attempts fired
+ * at it back to back, with no wait in between.
+ *
+ * @return true as soon as [isConnected] succeeded, false if all [maxTries] attempts failed.
+ */
+internal suspend fun awaitConnection(
+    maxTries: Int,
+    intervalMillis: Long,
+    isConnected: suspend () -> Boolean,
+): Boolean {
+    repeat(maxTries) {
+        if (isConnected()) return true
+        delay(intervalMillis)
+    }
+    return false
+}

--- a/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
+++ b/core/src/commonMain/kotlin/dev/kdriver/core/browser/DefaultBrowser.kt
@@ -262,11 +262,10 @@ open class DefaultBrowser(
         http = HTTPApi(config.host ?: "127.0.0.1", config.port ?: error("Port not set"))
 
         delay(config.browserConnectionTimeout)
-        repeat(config.browserConnectionMaxTries) {
-            if (testConnection()) return@repeat
-            delay(config.browserConnectionTimeout)
+        val connected = awaitConnection(config.browserConnectionMaxTries, config.browserConnectionTimeout) {
+            testConnection()
         }
-        logger.info("Connection to browser established")
+        if (connected) logger.info("Connection to browser established")
 
         val info = info ?: run {
             // Say what actually failed. Without this the only visible symptom is a 30s wait and a

--- a/core/src/jvmTest/kotlin/dev/kdriver/core/browser/AwaitConnectionTest.kt
+++ b/core/src/jvmTest/kotlin/dev/kdriver/core/browser/AwaitConnectionTest.kt
@@ -1,0 +1,67 @@
+package dev.kdriver.core.browser
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AwaitConnectionTest {
+
+    @Test
+    fun awaitConnection_whenTheBrowserAnswersImmediately_stopsPolling() = runTest {
+        var attempts = 0
+
+        val connected = awaitConnection(maxTries = 60, intervalMillis = 500) {
+            attempts++
+            true
+        }
+
+        assertTrue(connected)
+        // The whole point: one answer is enough. The previous `repeat { … return@repeat }` kept
+        // going for all 60 tries — and skipped the delay while doing so, so the browser got 60
+        // requests back to back right after it started.
+        assertEquals(1, attempts)
+    }
+
+    @Test
+    fun awaitConnection_whenTheBrowserAnswersLate_stopsAtThatAttempt() = runTest {
+        var attempts = 0
+
+        val connected = awaitConnection(maxTries = 60, intervalMillis = 500) {
+            attempts++
+            attempts >= 3
+        }
+
+        assertTrue(connected)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun awaitConnection_whenTheBrowserNeverAnswers_triesExactlyMaxTimes() = runTest {
+        var attempts = 0
+
+        val connected = awaitConnection(maxTries = 5, intervalMillis = 500) {
+            attempts++
+            false
+        }
+
+        assertFalse(connected)
+        assertEquals(5, attempts)
+    }
+
+    @Test
+    fun awaitConnection_waitsBetweenAttempts() = runTest {
+        var attempts = 0
+        val start = testScheduler.currentTime
+
+        awaitConnection(maxTries = 4, intervalMillis = 500) {
+            attempts++
+            false
+        }
+
+        // One interval per failed attempt, the last one included: that trailing wait is what the
+        // caller's "waited for N ms" error message counts.
+        assertEquals(4 * 500L, testScheduler.currentTime - start)
+    }
+}


### PR DESCRIPTION
## The bug

The wait loop in `DefaultBrowser.start()` reads as *"try until it connects, up to `maxTries` times"*:

```kotlin
delay(config.browserConnectionTimeout)
repeat(config.browserConnectionMaxTries) {
    if (testConnection()) return@repeat
    delay(config.browserConnectionTimeout)
}
```

`return@repeat` returns from the **lambda**, not from the loop — it is a `continue`, not a `break`. The loop never stopped early. And because the line it skipped is the `delay`, a browser that answered on the first try still got every remaining attempt fired at it **back to back, with no wait in between**.

This is the *successful* path, not an error path. Every browser start did it.

Standalone reproduction of the loop, run as-is:

```
testConnection() appelé : 60 fois
delay() exécuté        : 0 fois
```

So with the defaults, each successful start sends 60 `GET /json/version` in a burst at a Chrome that has just come up.

## The fix

The polling rule moves to `awaitConnection()`, so it can be tested without a real browser, and uses a genuine early return.

`start()` also now logs `"Connection to browser established"` only when the connection actually was established. It used to log it unconditionally — one line above the error saying the browser never opened its port, which is confusing when reading logs of a failed start.

## Not changed

The timeouts themselves. 60 tries × 500 ms is still 30 s of budget. It is worth revisiting (zendriver waits 2.5 s, pydoll 10 s), but that is a behaviour change and this is a bug fix — happy to do it in a follow-up.

## Tests

`AwaitConnectionTest`, written red first against a copy of the old loop:

| test | old loop | new |
|---|---|---|
| answers immediately → stops polling | ❌ 60 attempts, returns false | ✅ 1 attempt |
| answers on the 3rd try → stops there | ❌ | ✅ 3 attempts |
| never answers → exactly `maxTries` attempts | ✅ | ✅ |
| waits one interval per failed attempt | ✅ | ✅ |

The last two passed against the buggy version too — they pin the behaviour that must not change, so the fix cannot trade one bug for another.

Locally: all five targets compile, `:core:jvmTest` green, detekt findings identical to `main` (317, same set).